### PR TITLE
chore: block PYR bridging on mapped and default tokenlists

### DIFF
--- a/src/tokens/defaultTokens.json
+++ b/src/tokens/defaultTokens.json
@@ -655,15 +655,15 @@
             {
                 "wrappedTokenAddress": "0x430ef9263e76dae63c84292c3409d61c598e9682",
                 "wrappedNetworkId": -1,
-                "tags": ["pos", "erc20"]
+                "tags": ["pos", "erc20", "noDeposit", "noWithdraw"]
             },
             {
                 "wrappedTokenAddress": "0xc98d35ae65171aa38c0d6afd5416e4ba856afb86",
-                "tags": ["lxly", "erc20"]
+                "tags": ["lxly", "erc20", "noDeposit", "noWithdraw"]
             },
             {
                 "wrappedTokenAddress": "0x5d3cbb084cfa4b57af0765207540f9ac97c39b0b",
-                "tags": ["agglayer", "erc20"]
+                "tags": ["agglayer", "erc20", "noDeposit", "noWithdraw"]
             }
         ]
     },

--- a/src/tokens/mappedTokens.json
+++ b/src/tokens/mappedTokens.json
@@ -36873,7 +36873,9 @@
                 "wrappedNetworkId": -1,
                 "tags": [
                     "pos",
-                    "erc20"
+                    "erc20",
+                    "noDeposit",
+                    "noWithdraw"
                 ]
             }
         ]


### PR DESCRIPTION
## What

Tags **PYR Token** (`0x430ef9263e76dae63c84292c3409d61c598e9682`) with `noDeposit` and `noWithdraw` so it is no longer bridgeable.

| List | Wrapped tokens tagged |
|---|---|
| `mappedTokens.json` | `pos` |
| `defaultTokens.json` | `pos`, `lxly`, `agglayer` |

## Why the default list is included

Consumers key tokens by `chainId` + `originTokenAddress`, which is identical for this token in both lists. The popular/default list is processed first and its entry takes precedence — the mapped entry is discarded when both are present.

Tagging `mappedTokens.json` alone would therefore have had **no visible effect**. The default list is tagged as well so the block actually applies.

All three wrapped tokens on the default list are covered so every bridge route is closed, not just PoS.

## Scope

Staging lists (`mappedTokensStaging.json`, `defaultTokensStaging.json`) are intentionally left unchanged in this PR.

## Verification

- `npm run lint` — clean
- `npm run test-all` — 3 passing
- `npm run build` — regenerates `mapped.tokenlist.json` and `popular.tokenlist.json` with the new tags

## Note on base branch

Opened against `master` because both deploy workflows (`ecs_prod.yml`, `deploy_gcp.yaml`) trigger on `master`. The repository default branch is `dev`, which has diverged from `master` — this change will not reach `dev`.